### PR TITLE
handle course searching for trainee

### DIFF
--- a/src/modules/courses/course.controller.ts
+++ b/src/modules/courses/course.controller.ts
@@ -145,4 +145,14 @@ export class CourseController {
     ): Promise<AppResponse<UpdateResult>> {
         return await this.courseService.deleteSubjectForCourse(id, dto, user);
     }
+
+    @Roles(ERolesUser.TRAINEE)
+    @UseGuards(SessionAuthGuard, RolesGuard)
+    @Get('trainee/list')
+    async getCourseByTrainee(
+        @Query() dto: FindCourseDto,
+        @CurrentUserDecorator() user: User,
+    ): Promise<AppResponse<CourseWithoutCreatorDto[]>> {
+        return await this.courseService.getCourseForTrainee(dto, user);
+    }
 }


### PR DESCRIPTION
## Related Tickets
- Ticket: [[Redmine](https://edu-redmine.sun-asterisk.vn/issues/87423)]

## WHAT (Optional)
- Implement course search functionality for trainees.
## HOW
- Add logic to handle searching courses based on name and creator's name for trainees.

- Apply pagination using limit and skip.

- Return only the necessary fields using DTO (CourseWithoutCreatorDto).
## WHY (Optional)

## Evidence (Screenshot or Video)
> _Please attach screenshot or video here if available._
![image](https://github.com/user-attachments/assets/c08dbc71-052f-49c7-9115-24f7acb05104)


## Notes (Kiến thức tìm hiểu thêm)
> _Ghi chú kiến thức liên quan nếu có._
